### PR TITLE
Added GITHUB_OWNER for compatibility with Organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout repository
 
-      - uses: pmorelli92/github-container-registry-build-push@1.0.1
+      - uses: pmorelli92/github-container-registry-build-push@2.0.0
         name: Build and Publish latest service image
         with:
-          personal-access-token: ${{secrets.GITHUB_TOKEN}}
+          github-push-secret: ${{secrets.GITHUB_TOKEN}}
           docker-image-name: my-svc
           docker-image-tag: latest # optional
           dockerfile-path: ./src/svc/Dockerfile # optional

--- a/README.md
+++ b/README.md
@@ -15,17 +15,12 @@ jobs:
       - uses: pmorelli92/github-container-registry-build-push@1.0.1
         name: Build and Publish latest service image
         with:
-          # Read note below to see how to generate the PAT
-          personal-access-token: ${{secrets.GHCR_PAT}}
+          personal-access-token: ${{secrets.GITHUB_TOKEN}}
           docker-image-name: my-svc
-          docker-image-tag: latest
-          dockerfile-path: ./src/svc/Dockerfile
-          build-context: ./src/svc
+          docker-image-tag: latest # optional
+          dockerfile-path: ./src/svc/Dockerfile # optional
+          build-context: ./src/svc # optional
 ```
-
-## Generate PAT
-
-For generating the PAT (Personal Access Token) you can follow [this guide from GitHub.](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry). As the guide indicates, the PAT should be stored under the repository secret variables and referenced via `${{secrets.SECRET_NAME}}`.
 
 ## Inspirations and acknowledgments
 

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: 'Github Container Registry: Build and push Docker image'
 description: 'Github Action that builds and pushes a docker image to Github Container Registry.'
 inputs:
-  personal-access-token:
-    description: 'Token that has `write:packages` scope to authenticate against GCHR.'
+  github-push-secret:
+    description: 'Token such as GITHUB_TOKEN that has `write:packages` scope to authenticate against GCHR.'
     required: true
   docker-image-name:
     description: 'Docker Image name'
@@ -23,7 +23,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.personal-access-token }}
+    - ${{ inputs.github-push-secret }}
     - ${{ inputs.docker-image-name }}
     - ${{ inputs.docker-image-tag }}
     - ${{ inputs.dockerfile-path }}

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,8 @@ inputs:
     required: false
   dockerfile-path:
     description: 'Dockerfile path and name'
-    required: true
+    default: "Dockerfile"
+    required: false
   build-context:
     description: 'Path to the build context'
     default: "."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,10 @@ BUILD_CONTEXT=$5
 # Login to GHCR
 echo ${PERSONAL_ACCESS_TOKEN} | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
 
+GITHUB_OWNER=`echo ${GITHUB_REPOSITORY} | cut -d/ -f1`
+
 # Set up full image with tag
-IMAGE_ID=ghcr.io/${GITHUB_ACTOR}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+IMAGE_ID=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
 
 #TODO REMOVE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,8 @@ echo ${PERSONAL_ACCESS_TOKEN} | docker login https://ghcr.io -u ${GITHUB_ACTOR} 
 IMAGE_ID=ghcr.io/${GITHUB_ACTOR}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
 
+#TODO REMOVE
+echo build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 # Build image
 docker build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,23 +1,24 @@
 #!/bin/sh
 
-PERSONAL_ACCESS_TOKEN=$1
+GITHUB_PUSH_SECRET=$1
 DOCKER_IMAGE_NAME=$2
 DOCKER_IMAGE_TAG=$3
 DOCKERFILE_PATH=$4
 BUILD_CONTEXT=$5
 
 # Login to GHCR
-echo ${PERSONAL_ACCESS_TOKEN} | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+echo ${GITHUB_PUSH_SECRET} | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
 
+# GITHUB_REPOSITORY is always org/repo syntax. Get the owner in case it is different than the actor (when working in an org)
 GITHUB_OWNER=`echo ${GITHUB_REPOSITORY} | cut -d/ -f1`
 
 # Set up full image with tag
 IMAGE_ID=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
 
-#TODO REMOVE
-echo build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
+
 # Build image
+echo build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 docker build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 
 # Push image


### PR DESCRIPTION
When using an Organization's repository and actions, this action will fail due to the GITHUB_ACTOR and GITHUB_OWNER being different. I have internally introduced the GITHUB_OWNER variable to resolve this issue. Do let me know if you foresee any issues with this implementation.

This PR also includes some minor changes:

1. Updated readme to use built-in `GITHUB_TOKEN` as it is meant to supersede PATs. ["If your workflow is using a personal access token (PAT) to authenticate to ghcr.io, then we highly recommend you update your workflow to use GITHUB_TOKEN."](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry)
2. Added default dockerfile_path of `Dockerfile` in action.yml
3. Removed readme section on PAT since it is replaced by the built-in `GITHUB_TOKEN`

Let me know if you have any questions and thank you for writing this Github Action!