### PR TITLE
Add `build-only` flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker:stable
+RUN apk update && apk add bash
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
           docker-image-tag: latest # optional
           dockerfile-path: ./src/svc/Dockerfile # optional
           build-context: ./src/svc # optional
+          build-only: false # optional
 ```
 
 ## Inspirations and acknowledgments

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Path to the build context'
     default: "."
     required: false
+  build-only:
+    description: "If 'true', skip pushing the image"
+    default: "."
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -28,6 +32,7 @@ runs:
     - ${{ inputs.docker-image-tag }}
     - ${{ inputs.dockerfile-path }}
     - ${{ inputs.build-context}}
+    - ${{ inputs.build-only }}
 branding:
   icon: 'box'
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
   build-only:
     description: "If 'true', skip pushing the image"
-    default: "."
+    default: "false"
     required: false
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 GITHUB_PUSH_SECRET=$1
 DOCKER_IMAGE_NAME=$2
 DOCKER_IMAGE_TAG=$3
 DOCKERFILE_PATH=$4
 BUILD_CONTEXT=$5
+BUILD_ONLY=$6
 
 # Login to GHCR
 echo ${GITHUB_PUSH_SECRET} | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
@@ -22,4 +23,8 @@ echo build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 docker build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 
 # Push image
-docker push ${IMAGE_ID}
+if [ "$BUILD_ONLY" == "true" ]; then
+	echo "skipping push"
+else 
+	docker push ${IMAGE_ID}
+fi


### PR DESCRIPTION
The build-only flag allows for PRs to check that images build correctly without necessarily pushing a the image the container registry. 